### PR TITLE
Rename basicauth to basic_auth

### DIFF
--- a/caddy/check.ci.ocaml.org
+++ b/caddy/check.ci.ocaml.org
@@ -6,7 +6,7 @@ check.ci.ocaml.org {
 	@paths {
 		path /metrics /host/metrics
 	}
-	basicauth @paths {
+	basic_auth @paths {
 		prometheus {{ prometheus_password }}
 	}
 	handle /host/metrics {
@@ -17,7 +17,7 @@ check.ci.ocaml.org {
 }
 
 freebsd.check.ci.dev {
-	basicauth /metrics {
+	basic_auth /metrics {
 		prometheus {{ prometheus_password }}
 	}
 	reverse_proxy opam-health-check-freebsd:8080

--- a/caddy/deploy.ci.dev
+++ b/caddy/deploy.ci.dev
@@ -3,8 +3,5 @@ deploy.ci3.ocamllabs.io {
 }
 
 deploy.ci.dev {
-	basicauth bcrypt {
-		prometheus {{ prometheus_password }}
-	}
 	reverse_proxy deployer:8080
 }

--- a/caddy/docs.ci.ocaml.org
+++ b/caddy/docs.ci.ocaml.org
@@ -1,6 +1,6 @@
 docs.ci.ocaml.org {
 	handle /host/metrics {
-		basicauth bcrypt {
+		basic_auth bcrypt {
 			prometheus {{ prometheus_password }}
 		}
 		uri strip_prefix /host

--- a/caddy/images.ci.ocaml.org
+++ b/caddy/images.ci.ocaml.org
@@ -1,13 +1,13 @@
 images.ci.ocaml.org {
 	handle /host/metrics {
-		basicauth bcrypt {
+		basic_auth bcrypt {
 			prometheus {{ prometheus_password }}
 		}
 		uri strip_prefix /host
 		reverse_proxy 172.17.0.1:9090
 	}
 	handle /metrics {
-		basicauth bcrypt {
+		basic_auth bcrypt {
 			prometheus {{ prometheus_password }}
 		}
 		reverse_proxy builder:8080

--- a/caddy/ocaml.ci.dev
+++ b/caddy/ocaml.ci.dev
@@ -41,7 +41,7 @@ status.ocaml.ci.dev {
 }
 
 prometheus.ci.dev {
-        basicauth bcrypt {
+        basic_auth bcrypt {
 		prometheus {{ prometheus_password }}
         }
         reverse_proxy prometheus:9090

--- a/caddy/opam.ci.ocaml.org
+++ b/caddy/opam.ci.ocaml.org
@@ -1,13 +1,13 @@
 opam-repo.ci.ocaml.org {
 	handle /host/metrics {
-		basicauth bcrypt {
+		basic_auth bcrypt {
 			prometheus {{ prometheus_password }}
 		}
 		uri strip_prefix /host
 		reverse_proxy 172.17.0.1:9090
 	}
 	handle /metrics {
-		basicauth bcrypt {
+		basic_auth bcrypt {
 			prometheus {{ prometheus_password }}
 		}
 		reverse_proxy opam-repo-ci:8080

--- a/caddy/scheduler.ci.dev
+++ b/caddy/scheduler.ci.dev
@@ -1,5 +1,5 @@
 scheduler.ci.dev {
-	basicauth bcrypt {
+	basic_auth bcrypt {
 		prometheus {{ prometheus_password }}
 	}
 	reverse_proxy prometheus:9090


### PR DESCRIPTION
After Caddy v2.8.0, `basicauth` was renamed for consistency with other directives.