### PR TITLE
Try caddy with cache-handle on staging.ocaml.org

### DIFF
--- a/caddy/staging.ocaml.org
+++ b/caddy/staging.ocaml.org
@@ -1,4 +1,10 @@
+{
+	cache
+}
 v3c.ocaml.org, staging.ocaml.org {
+	cache {
+		ttl 240s
+	}
 	handle /host/metrics {
 		basic_auth bcrypt {
 			prometheus {{ prometheus_password }}

--- a/staging.ocaml.org.yml
+++ b/staging.ocaml.org.yml
@@ -50,7 +50,7 @@
                     published: 443
                     protocol: tcp
                     mode: host
-                image: caddy
+                image: shonfeder/caddy-cache-handler
                 volumes:
                   - /etc/caddy:/etc/caddy:ro
                   - caddy_data:/data


### PR DESCRIPTION
This configures staging.ocaml.org to use caddy build with the cache
handler, defined at https://github.com/ocurrent/caddy-cache-handler

Is is currently just using a docker image pushed to my dockerhub
account, but if this works as expected, we will followup with a docker
image created via the deployer and hosted on the ocurrent org.