### PR TITLE
Add rate limiting to ocaml.org

### DIFF
--- a/www.ocaml.org.yml
+++ b/www.ocaml.org.yml
@@ -292,7 +292,7 @@
                     published: 80
                     protocol: tcp
                     mode: host
-                image: varnish:stable
+                image: varnish:7.5
                 volumes:
                   - /etc/varnish:/etc/varnish
                 tmpfs:

--- a/www.ocaml.org.yml
+++ b/www.ocaml.org.yml
@@ -59,7 +59,9 @@
           
           import proxy;
           import directors;
-          
+          # See https://github.com/varnish/varnish-modules/blob/master/src/vmod_vsthrottle.vcc
+          import vsthrottle;
+
           probe health {
               .url = "/";
           }
@@ -93,6 +95,11 @@
           }
           
           sub vcl_recv {
+              if (vsthrottle.is_denied(client.identity, 15, 10s, 30s)) {
+                  # Client has exceeded 15 reqs per 10s.
+                  # When this happens, block altogether for the next 30s.
+                  return (synth(429, "Too Many Requests"));
+              }
               if (req.url ~ "^/metrics") {
                 if (!req.http.Authorization ~ "Basic {{ prometheus_password }}") {
                   return(synth(401, "Restricted"));

--- a/www.ocaml.org.yml
+++ b/www.ocaml.org.yml
@@ -95,9 +95,13 @@
           }
           
           sub vcl_recv {
-              if (vsthrottle.is_denied(client.identity, 15, 10s, 30s)) {
-                  # Client has exceeded 15 reqs per 10s.
+              if (vsthrottle.is_denied(client.identity, 500, 1s, 30s)) {
+                  # Client has exceeded 500 reqs per 1s.
                   # When this happens, block altogether for the next 30s.
+                  # Loading ocaml.org maked 42 sequsets. A very fast click rate
+                  # is 10 clicks/second. 42 * 10 is a venerable number,
+                  # but we round the limit up to 500 for a more professional
+                  # buffer.
                   return (synth(429, "Too Many Requests"));
               }
               if (req.url ~ "^/metrics") {


### PR DESCRIPTION
This adds rate limiting to protect against DOS attacks.

See https://github.com/varnish/varnish-modules/blob/master/src/vmod_vsthrottle.vcc for documentation on vmod_throttle.

I have prepared the same configuration for the staging.ci.dev server, but my SSH access has been revoked, so I have not been able to test the configuration. See those changes in the branch https://github.com/ocaml-infrastructure/ansible/commits/alpha-test-rate-limits/